### PR TITLE
Add cfn to create IAM Roles & add cloud9 permission to devUser

### DIFF
--- a/Persona_Roles.yaml
+++ b/Persona_Roles.yaml
@@ -1,0 +1,86 @@
+Description: Stack to create roles for Code approval
+Resources:
+ CodeGuruPolicy:
+  Type: 'AWS::IAM::ManagedPolicy'
+  Properties:
+    PolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Action:
+            - "codeguru-reviewer:ListRecommendations"
+          Resource: '*'
+ ApproverWritePolicy:
+  Type: 'AWS::IAM::ManagedPolicy'
+  Properties:
+    PolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Action:
+           - "codecommit:PostCommentForPullRequest"
+           - "codecommit:UpdatePullRequestApprovalState"
+          Resource: '*'
+ RoleRepositoryAdmin:
+  Type: AWS::IAM::Role
+  Properties: 
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            AWS:
+              Ref: AWS::AccountId
+          Action:
+            - 'sts:AssumeRole'
+    Description: RoleRepositoryAdmin
+    ManagedPolicyArns: 
+      - arn:aws:iam::aws:policy/AWSCodeCommitFullAccess
+      - !Ref CodeGuruPolicy
+    RoleName: "RoleRepositoryAdmin"
+ RoleCodeApprover:
+  Type: AWS::IAM::Role
+  Properties: 
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            AWS:
+              Ref: AWS::AccountId
+          Action:
+            - 'sts:AssumeRole'
+    Description: RoleCodeApprover
+    ManagedPolicyArns: 
+      - arn:aws:iam::aws:policy/AWSCodeCommitReadOnly
+      - !Ref CodeGuruPolicy
+      - !Ref ApproverWritePolicy
+    RoleName: "RoleCodeApprover"
+ RoleCodeDeveloper:
+  Type: AWS::IAM::Role
+  Properties: 
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal: 
+            AWS:
+              Ref: AWS::AccountId
+          Action:
+            - 'sts:AssumeRole'
+    Description: RoleCodeDeveloper
+    ManagedPolicyArns: 
+      - arn:aws:iam::aws:policy/AWSCodeCommitPowerUser
+      - arn:aws:iam::aws:policy/AWSCloud9User
+      - !Ref CodeGuruPolicy
+    MaxSessionDuration: 36000
+    Policies:
+     - PolicyName: denyapprovalrule
+       PolicyDocument:
+        Version: '2012-10-17'
+        Statement: 
+          - Effect: Deny
+            Action:
+            - "codecommit:CreatePullRequestApprovalRule"
+            Resource: '*'
+    RoleName: "RoleCodeDeveloper"

--- a/Persona_Users.yaml
+++ b/Persona_Users.yaml
@@ -56,6 +56,7 @@ Resources:
         PasswordResetRequired: True
     ManagedPolicyArns: 
       - arn:aws:iam::aws:policy/AWSCodeCommitPowerUser
+      - arn:aws:iam::aws:policy/AWSCloud9User
       - !Ref CodeGuruPolicy
     Policies:
      - PolicyName: denyapprovalrule


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding a cloudformation template to create IAM Roles for the CodeDeveloper, CodeApprover & Repository Admin personas.

Added a permission to use Cloud9 for the UserCodeDeveloper IAM User otherwise folks following the blog steps won't be able to do all the steps.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
